### PR TITLE
Remove `/usr/bin/ruby` when executing settings script.

### DIFF
--- a/ios/RNHeap.xcodeproj/project.pbxproj
+++ b/ios/RNHeap.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "# pwd is <client_app>/node_modules/@heap/react-native-heap/ios\n\n/usr/bin/ruby HeapSettings.bundle/generate_settings_non_cocoapods.rb\n";
+			shellScript = "# pwd is <client_app>/node_modules/@heap/react-native-heap/ios\n\nHeapSettings.bundle/generate_settings_non_cocoapods.rb\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     name: 'Generate `HeapSettings.plist`',
-    script: '/usr/bin/ruby ../../node_modules/@heap/react-native-heap/ios/HeapSettings.bundle/generate_settings',
+    script: '../../node_modules/@heap/react-native-heap/ios/HeapSettings.bundle/generate_settings',
     execution_position: :after_compile,
     shell_path: '/bin/bash'
   }


### PR DESCRIPTION
With `/usr/bin/ruby`, it uses the system's ruby version. If the user has `rvm` or `rbenv` to manage the ruby versions and they don't use the the system's one and the script failed because dependencies issues:
```
[10:39:44]: ▸ Ignoring json-2.2.0 because its extensions are not built.  Try: gem pristine json --version 2.2.0
[10:39:44]: ▸ Ignoring unf_ext-0.0.7.6 because its extensions are not built.  Try: gem pristine unf_ext --version 0.0.7.6
[10:39:44]: ▸ /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
[10:39:44]: ▸ 	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
[10:39:44]: ▸ Command /bin/sh failed with exit code 1
```

Removing that, it will use the `#!/usr/bin/env ruby` on top of the script files to look in the `$PATH` where to find the binary and would work for people with a ruby version manager or with the system's version as well.

Another option would be to call the scripts with just `ruby`.

Tested this with our own project and it works. Not sure if there any test that I should modify as well.